### PR TITLE
Certificate forward

### DIFF
--- a/adsutils.cc
+++ b/adsutils.cc
@@ -1,11 +1,11 @@
 #include "main.h"
 
 
-NameDBEntry::NameDBEntry(std::string& _dc_name, Ipv4Address& _origin_AS_addr, std::string& _td_path, Ipv4Address& _origin_server) {
+NameDBEntry::NameDBEntry(std::string& _dc_name, Ipv4Address& _origin_AS_addr, std::string& _td_path, Ipv4Address& _origin_server, CertInfo _cert_info) {
     dc_name = _dc_name;
     origin_AS_addr = _origin_AS_addr;
     origin_server = _origin_server;
-    
+    cert_info = _cert_info;
     
     // deserialize the td_path to vector
     // td_path is in the form: A->B->C->D
@@ -46,7 +46,23 @@ NameDBEntry* NameDBEntry::FromAdvertisementStr(std::string& serialized) {
     std::string td_path = deserializeRoot.get("td_path", "").asString();
     Ipv4Address origin_AS_addr = Ipv4Address(deserializeRoot.get("origin_AS", "123.123.123.123").asString().c_str());
     Ipv4Address origin_server = Ipv4Address(deserializeRoot.get("origin_server", "123.123.123.123").asString().c_str());
-    return new NameDBEntry(dc_name, origin_AS_addr, td_path, origin_server);
+    Json::Value CertInfoRoot = deserializeRoot.get("cert_info", "");
+    CertInfo cert_info;
+    if (CertInfoRoot != "") {
+        cert_info.type = CertInfoRoot.get("type", "").asString();
+        cert_info.entity = CertInfoRoot.get("entity", "").asString();
+        cert_info.issuer = CertInfoRoot.get("issuer", "").asString();
+        cert_info.r_transitivity = CertInfoRoot.get("r_transitivity", 0).asInt();
+    } else {
+        // set default values for cert_info
+        cert_info.entity = "";
+        cert_info.type = "";
+        cert_info.issuer = "";
+        cert_info.r_transitivity = 0;
+    }
+    auto* entry = new NameDBEntry(dc_name, origin_AS_addr, td_path, origin_server, cert_info);
+
+    return entry;
 }
 
 
@@ -70,6 +86,14 @@ std::string NameDBEntry::ToAdvertisementStr() {
     ss.str(std::string());
     origin_server.Print(ss);
     serializeRoot["origin_server"] = ss.str();
+
+    Json::Value cert;
+    cert["type"] = cert_info.type;
+    cert["entity"] = cert_info.entity;
+    cert["issuer"] = cert_info.issuer;
+    cert["r_transitivity"] = cert_info.r_transitivity;
+
+    serializeRoot["cert_info"] = cert;
     // serialize the packet
     Json::StyledWriter writer;
     return writer.write(serializeRoot);;

--- a/adsutils.cc
+++ b/adsutils.cc
@@ -1,12 +1,18 @@
 #include "main.h"
 
-
-NameDBEntry::NameDBEntry(std::string& _dc_name, Ipv4Address& _origin_AS_addr, std::string& _td_path, Ipv4Address& _origin_server, CertInfo _cert_info) {
+NameDBEntry::NameDBEntry(std::string& _dc_name,
+                         Ipv4Address& _origin_AS_addr,
+                         std::string& _td_path,
+                         Ipv4Address& _origin_server,
+                         TrustCert _trust_cert,
+                         std::vector<DistrustCert> _distrust_certs)
+{
     dc_name = _dc_name;
     origin_AS_addr = _origin_AS_addr;
     origin_server = _origin_server;
-    cert_info = _cert_info;
-    
+    trust_cert = _trust_cert;
+    distrust_certs = _distrust_certs;
+
     // deserialize the td_path to vector
     // td_path is in the form: A->B->C->D
     // we want a vector containing {A, B, C, D}
@@ -14,91 +20,128 @@ NameDBEntry::NameDBEntry(std::string& _dc_name, Ipv4Address& _origin_AS_addr, st
     std::string segment = _td_path;
     std::string delimiter = "->";
     std::string td_to_add = segment.substr(0, segment.find(delimiter));
-    while (td_to_add.size() != 0) {
+    while (td_to_add.size() != 0)
+    {
         td_path.push_back(Ipv4Address(td_to_add.c_str()));
-        if (td_to_add.size()+2 < segment.size()) {
-            segment = segment.substr(td_to_add.size()+2);
-        } else {
+        if (td_to_add.size() + 2 < segment.size())
+        {
+            segment = segment.substr(td_to_add.size() + 2);
+        }
+        else
+        {
             segment = segment.substr(segment.size());
         }
         td_to_add = segment.substr(0, segment.find(delimiter));
     }
     // std::cout << "size of deserialized td_path is: " << td_path.size() << std::endl;
-
-    
 }
 
-
-NameDBEntry::~NameDBEntry() {
+NameDBEntry::~NameDBEntry()
+{
     // std::cout << "NameDBEntry destructor called" << std::endl;
 }
 
-
-NameDBEntry* NameDBEntry::FromAdvertisementStr(std::string& serialized) {
+NameDBEntry*
+NameDBEntry::FromAdvertisementStr(std::string& serialized)
+{
     // * deserialize the advertisement packet
     Json::Value deserializeRoot;
     Json::Reader reader;
-    if (!reader.parse(serialized, deserializeRoot)) {
+    if (!reader.parse(serialized, deserializeRoot))
+    {
         // std::cout << "Cannot parse ads: " << serialized << std::endl;
         return nullptr;
     }
     std::string dc_name = deserializeRoot.get("dc_name", "empty").asString();
     std::string td_path = deserializeRoot.get("td_path", "").asString();
-    Ipv4Address origin_AS_addr = Ipv4Address(deserializeRoot.get("origin_AS", "123.123.123.123").asString().c_str());
-    Ipv4Address origin_server = Ipv4Address(deserializeRoot.get("origin_server", "123.123.123.123").asString().c_str());
-    Json::Value CertInfoRoot = deserializeRoot.get("cert_info", "");
-    CertInfo cert_info;
-    if (CertInfoRoot != "") {
-        cert_info.type = CertInfoRoot.get("type", "").asString();
-        cert_info.entity = CertInfoRoot.get("entity", "").asString();
-        cert_info.issuer = CertInfoRoot.get("issuer", "").asString();
-        cert_info.r_transitivity = CertInfoRoot.get("r_transitivity", 0).asInt();
-    } else {
-        // set default values for cert_info
-        cert_info.entity = "";
-        cert_info.type = "";
-        cert_info.issuer = "";
-        cert_info.r_transitivity = 0;
+    Ipv4Address origin_AS_addr =
+        Ipv4Address(deserializeRoot.get("origin_AS", "123.123.123.123").asString().c_str());
+    Ipv4Address origin_server =
+        Ipv4Address(deserializeRoot.get("origin_server", "123.123.123.123").asString().c_str());
+    
+    // Parsing trust relation
+    Json::Value trust_cert_root = deserializeRoot.get("trust_cert", "");
+    TrustCert trust_cert;
+    if (trust_cert_root != "")
+    {
+        trust_cert.type = trust_cert_root.get("type", "").asString();
+        trust_cert.entity = trust_cert_root.get("entity", "").asString();
+        trust_cert.issuer = trust_cert_root.get("issuer", "").asString();
+        trust_cert.r_transitivity = trust_cert_root.get("r_transitivity", 0).asInt();
     }
-    auto* entry = new NameDBEntry(dc_name, origin_AS_addr, td_path, origin_server, cert_info);
+    else
+    {
+        // set default values for trust_cert
+        trust_cert.entity = "";
+        trust_cert.type = "";
+        trust_cert.issuer = "";
+        trust_cert.r_transitivity = 0;
+    }
 
+    //  Parsing distrust relation
+    Json::Value distrust_cert_root = deserializeRoot.get("distrust_certs", Json::Value(Json::arrayValue));
+    std::vector<DistrustCert> distrust_certs;
+    if (distrust_cert_root != Json::Value(Json::arrayValue)) {
+        for (unsigned int i = 0; i < distrust_cert_root.size(); ++i) {
+            DistrustCert distrust;
+            distrust.type = distrust_cert_root[i].get("type", "").asString();
+            distrust.entity = distrust_cert_root[i].get("entity", "").asString();
+            distrust.issuer = distrust_cert_root[i].get("issuer", "").asString();
+
+            distrust_certs.push_back(distrust);
+        }
+    }
+
+    auto* entry = new NameDBEntry(dc_name, origin_AS_addr, td_path, origin_server, trust_cert, distrust_certs);
     return entry;
 }
 
-
-std::string NameDBEntry::ToAdvertisementStr() {
+std::string
+NameDBEntry::ToAdvertisementStr()
+{
     Json::Value serializeRoot;
     serializeRoot["dc_name"] = dc_name;
 
     std::stringstream td_path_str;
-    for (Ipv4Address addr : td_path) {
+    for (Ipv4Address addr : td_path)
+    {
         std::stringstream ss;
         addr.Print(ss);
         td_path_str << ss.str() << "->";
     }
     std::string result = td_path_str.str();
-    serializeRoot["td_path"] = result.substr(0, result.size()-2);
-    
+    serializeRoot["td_path"] = result.substr(0, result.size() - 2);
+
     std::stringstream ss;
     origin_AS_addr.Print(ss);
     serializeRoot["origin_AS"] = ss.str();
-    
+
     ss.str(std::string());
     origin_server.Print(ss);
     serializeRoot["origin_server"] = ss.str();
 
+    // Add trust relation information
     Json::Value cert;
-    cert["type"] = cert_info.type;
-    cert["entity"] = cert_info.entity;
-    cert["issuer"] = cert_info.issuer;
-    cert["r_transitivity"] = cert_info.r_transitivity;
+    cert["type"] = trust_cert.type;
+    cert["entity"] = trust_cert.entity;
+    cert["issuer"] = trust_cert.issuer;
+    cert["r_transitivity"] = trust_cert.r_transitivity;
 
-    serializeRoot["cert_info"] = cert;
+    serializeRoot["trust_cert"] = cert;
+
+    // Add distrust relation information
+    Json::Value d_certs = Json::Value(Json::arrayValue);
+    for (unsigned int i = 0; i < distrust_certs.size(); ++i) {
+        Json::Value d_cert;
+        d_cert["type"] = distrust_certs[i].type;
+        d_cert["entity"] = distrust_certs[i].entity;
+        d_cert["issuer"] = distrust_certs[i].issuer;
+        d_certs.append(d_cert);
+    }
+
+    serializeRoot["distrust_certs"] = d_certs;
     // serialize the packet
     Json::StyledWriter writer;
-    return writer.write(serializeRoot);;
+    return writer.write(serializeRoot);
+    ;
 }
-
-
-
-

--- a/brite-conf.conf
+++ b/brite-conf.conf
@@ -6,7 +6,7 @@ BriteConfig
 
 BeginModel
 	Name = 5		 #Top Down = 5
-	edgeConn = 2		 #Random=1, Smallest Nonleaf = 2, Smallest Deg = 3, k-Degree=4
+	edgeConn = 3		 #Random=1, Smallest Nonleaf = 2, Smallest Deg = 3, k-Degree=4
 	k = -1			 #Only needed if edgeConn is set to K-Degree, otherwise use -1
 	BWInter = 1		 #Constant = 1, Uniform =2, HeavyTailed = 3, Exponential =4
 	BWInterMin = 10.0

--- a/dcowner.cc
+++ b/dcowner.cc
@@ -1,0 +1,130 @@
+#include "main.h"
+
+
+namespace ns3
+{
+    NS_LOG_COMPONENT_DEFINE("DCOwner");
+
+    NS_OBJECT_ENSURE_REGISTERED(DCOwner);
+
+    TypeId
+    DCOwner::GetTypeId()
+    {
+        static TypeId tid =
+            TypeId("ns3::DCOwner")
+                .SetParent<Application>()
+                .SetGroupName("Applications")
+                .AddConstructor<DCOwner>();
+        return tid;
+    }
+
+    DCOwner::DCOwner()
+    {
+        NS_LOG_FUNCTION(this);
+    }
+
+    DCOwner::~DCOwner()
+    {
+        NS_LOG_FUNCTION(this);
+    }
+
+    void
+    DCOwner::DoDispose()
+    {
+        NS_LOG_FUNCTION(this);
+        Application::DoDispose();
+    }
+
+    void
+    DCOwner::StartApplication()
+    {
+        NS_LOG_FUNCTION(this);
+
+        for (auto it = certs_to_send.begin(); it != certs_to_send.end(); it++){
+            TypeId tid = TypeId::LookupByName("ns3::UdpSocketFactory");
+            Ptr<Socket> m_socket = Socket::CreateSocket(GetNode(), tid);
+            Address m_peerAddress = it->rib_addr;
+            if (Ipv4Address::IsMatchingType(m_peerAddress) == true)
+            {
+                if (m_socket->Bind() == -1)
+                {
+                    NS_FATAL_ERROR("Failed to bind socket");
+                }
+                m_socket->Connect(
+                    InetSocketAddress(Ipv4Address::ConvertFrom(m_peerAddress), RIBCERTSTORE_PORT));
+            }
+            else if (Ipv6Address::IsMatchingType(m_peerAddress) == true)
+            {
+                if (m_socket->Bind6() == -1)
+                {
+                    NS_FATAL_ERROR("Failed to bind socket");
+                }
+                m_socket->Connect(
+                    Inet6SocketAddress(Ipv6Address::ConvertFrom(m_peerAddress), RIBCERTSTORE_PORT));
+            }
+            else if (InetSocketAddress::IsMatchingType(m_peerAddress) == true)
+            {
+                if (m_socket->Bind() == -1)
+                {
+                    NS_FATAL_ERROR("Failed to bind socket");
+                }
+                m_socket->Connect(m_peerAddress);
+            }
+            else if (Inet6SocketAddress::IsMatchingType(m_peerAddress) == true)
+            {
+                if (m_socket->Bind6() == -1)
+                {
+                    NS_FATAL_ERROR("Failed to bind socket");
+                }
+                m_socket->Connect(m_peerAddress);
+            }
+            else
+            {
+                NS_ASSERT_MSG(false, "Incompatible address type: " << m_peerAddress);
+            }
+            m_socket->SetRecvCallback(MakeNullCallback<void, Ptr<Socket>>());
+            m_socket->SetAllowBroadcast(true);
+
+            Simulator::Schedule(Seconds(0.5), &DCOwner::Send, this, m_socket, *it);
+        }
+
+
+    }
+
+    void
+    DCOwner::StopApplication()
+    {
+        NS_LOG_FUNCTION(this);
+    }
+
+    void
+    DCOwner::Send(Ptr<Socket> sock, CertInfo cinfo)
+    {
+        NS_LOG_FUNCTION(this);
+
+        SeqTsHeader seqTs;
+        seqTs.SetSeq(0xffff);
+
+        NS_LOG_INFO("Sending cert to: " << cinfo.rib_addr);
+        Json::Value root;
+
+        std::stringstream ss;
+        ss << my_name << ":" << cinfo.issuer;
+        root["issuer"] = ss.str();
+        root["type"] = cinfo.type;
+        root["entity"] = cinfo.entity;
+
+        Json::StyledWriter jsonWriter;
+        std::string body = jsonWriter.write(root);
+
+        Ptr<Packet> p = Create<Packet>((const uint8_t *)body.c_str(), body.size());
+        p->AddHeader(seqTs);
+
+
+        if ((sock->Send(p)) >= 0)
+        {
+            sock->Close();
+        }
+    }
+
+}

--- a/main.cc
+++ b/main.cc
@@ -235,6 +235,7 @@ main(int argc, char* argv[])
     bth.BuildBriteTopology(stack);
     bth.AssignIpv4Addresses(address);
 
+    
     NS_LOG_INFO("Number of AS created " << bth.GetNAs());
     std::map<std::string, int> addr_map;
 
@@ -244,6 +245,7 @@ main(int argc, char* argv[])
 
     // Same AS as the DCServerAdvertiser below.
     BUILD_P2P(dcOwner, 9, "11.3.0.0")
+
 
     address.SetBase(SERVER_SUBNET, COMMON_MASK); // * 1 server per AS
     auto serverAssgn = randomNodeAssignment(
@@ -392,6 +394,49 @@ main(int argc, char* argv[])
 
     dummyClientApp.Start(Seconds(50.0));
     dummyClientApp.Stop(Seconds(600.0));
+
+
+    MobilityHelper mh;
+    mh.InstallAll();
+    std::default_random_engine rGen;
+    std::normal_distribution<double> rDist(0.0, 10.0);
+
+    for (int i = 0; i < bth.GetNAs(); i++){
+        double asX = 200 * cos(2 * 3.14 * (double)i / bth.GetNAs());
+        double asY = 200 * sin(2 * 3.14 * (double)i / bth.GetNAs());
+        for (int j = 0; j < bth.GetNNodesForAs(i); j++){
+            Ptr<Node> n = bth.GetNodeForAs(i, j);
+            double r = rDist(rGen);
+            double x = asX + r * cos(2 * 3.14 * (double)j / bth.GetNNodesForAs(i));
+            double y = asY + r * sin(2 * 3.14 * (double)j / bth.GetNNodesForAs(i));
+            n->GetObject<MobilityModel>()->SetPosition({x, y, 0});
+        }
+
+        for (int j = 0; j < bth.GetNLeafNodesForAs(i); j++){
+            Ptr<Node> n = bth.GetLeafNodeForAs(i, j);
+            double r = 5 + rDist(rGen);
+            double x = asX + r * cos(2 * 3.14 * (double)j / bth.GetNLeafNodesForAs(i));
+            double y = asY + r * sin(2 * 3.14 * (double)j / bth.GetNLeafNodesForAs(i));
+            n->GetObject<MobilityModel>()->SetPosition({x, y, 0});
+        }
+
+        for (int j = 0; j < switchAssgn[i].first.GetN(); j++){
+            Ptr<Node> n = switchAssgn[i].first.Get(j);
+            double r = 10 + rDist(rGen);
+            double x = asX + r * cos(2 * 3.14 * (double)j / switchAssgn[i].first.GetN());
+            double y = asY + r * sin(2 * 3.14 * (double)j / switchAssgn[i].first.GetN());
+            n->GetObject<MobilityModel>()->SetPosition({x, y, 0});
+        }
+
+        for (int j = 0; j < serverAssgn[i].first.GetN(); j++){
+            Ptr<Node> n = serverAssgn[i].first.Get(j);
+            double r = 10 + rDist(rGen);
+            double x = asX + r * cos(2 * 3.14 * (double)j / serverAssgn[i].first.GetN());
+            double y = asY + r * sin(2 * 3.14 * (double)j / serverAssgn[i].first.GetN());
+            n->GetObject<MobilityModel>()->SetPosition({x, y, 0});
+        }
+    }
+
 
 
     if (!nix)

--- a/main.cc
+++ b/main.cc
@@ -190,6 +190,7 @@ main(int argc, char* argv[])
     LogComponentEnable("RIBAdStore", LOG_LEVEL_ALL);
     LogComponentEnable("RIBCertStore", LOG_LEVEL_ALL);
     LogComponentEnable("RIBLinkStateManager", LOG_LEVEL_ALL);
+    LogComponentEnable("RIBPathComputer", LOG_LEVEL_ALL);
     LogComponentEnable("DCServerAdvertiser", LOG_LEVEL_ALL);
     LogComponentEnable("OverlaySwitchPingClient", LOG_LEVEL_ALL);
     LogComponentEnable("OverlaySwitchForwardingEngine", LOG_LEVEL_ALL);

--- a/main.h
+++ b/main.h
@@ -525,14 +525,20 @@ class DCServer
 class NameDBEntry
 {
 public:
-    struct CertInfo {
+    struct TrustCert {
         std::string type;
         std::string entity;
         std::string issuer;
         int r_transitivity;
     };
 
-    NameDBEntry(std::string& _dc_name, Ipv4Address& _origin_AS_addr, std::string& _td_path, Ipv4Address&  _origin_server, CertInfo _cert_info);
+    struct DistrustCert {
+        std::string type;
+        std::string entity;
+        std::string issuer;
+    };
+
+    NameDBEntry(std::string& _dc_name, Ipv4Address& _origin_AS_addr, std::string& _td_path, Ipv4Address&  _origin_server, TrustCert _trust_cert, std::vector<DistrustCert> _distrust_cert);
 
     ~NameDBEntry();
 
@@ -543,7 +549,8 @@ public:
     Ipv4Address origin_AS_addr;
     std::vector<Ipv4Address> td_path;
     Ipv4Address origin_server;
-    CertInfo cert_info;
+    TrustCert trust_cert;
+    std::vector<DistrustCert> distrust_certs;
 
     // possibly also expire time...
 

--- a/main.h
+++ b/main.h
@@ -525,7 +525,14 @@ class DCServer
 class NameDBEntry
 {
 public:
-    NameDBEntry(std::string& _dc_name, Ipv4Address& _origin_AS_addr, std::string& _td_path, Ipv4Address&  _origin_server);
+    struct CertInfo {
+        std::string type;
+        std::string entity;
+        std::string issuer;
+        int r_transitivity;
+    };
+
+    NameDBEntry(std::string& _dc_name, Ipv4Address& _origin_AS_addr, std::string& _td_path, Ipv4Address&  _origin_server, CertInfo _cert_info);
 
     ~NameDBEntry();
 
@@ -536,6 +543,7 @@ public:
     Ipv4Address origin_AS_addr;
     std::vector<Ipv4Address> td_path;
     Ipv4Address origin_server;
+    CertInfo cert_info;
 
     // possibly also expire time...
 

--- a/rib.cc
+++ b/rib.cc
@@ -31,12 +31,22 @@ ApplicationContainer RIB::Install(Ptr<Node> node)
     node->AddApplication(linkManager);
     this->liveSwitches = &linkManager->liveSwitches;
 
+
+    certStoreFactory.SetTypeId(RIBCertStore::GetTypeId());
+    certStore = certStoreFactory.Create<RIBCertStore>();
+    certStore->SetAttribute("Port", UintegerValue(RIBCERTSTORE_PORT));
+    node->AddApplication(certStore);
+    this->trustRelations = &certStore->trustRelations;
+    this->distrustRelations = &certStore->distrustRelations;
+
     linkManager->SetContext((void *)this);
     adStore->SetContext((void *)this);
+    certStore->SetContext((void *)this);
     
     ApplicationContainer apps;
     apps.Add(adStore);
     apps.Add(linkManager);
+    apps.Add(certStore);
 
     return apps;
 }

--- a/rib.cc
+++ b/rib.cc
@@ -31,6 +31,10 @@ ApplicationContainer RIB::Install(Ptr<Node> node)
     node->AddApplication(linkManager);
     this->liveSwitches = &linkManager->liveSwitches;
 
+    pathComputerFactory.SetTypeId(RIBPathComputer::GetTypeId());
+    pathComputer = pathComputerFactory.Create<RIBPathComputer>();
+    pathComputer->SetAttribute("Port", UintegerValue(RIBPATHCOMPUTER_PORT));
+    node->AddApplication(pathComputer);
 
     certStoreFactory.SetTypeId(RIBCertStore::GetTypeId());
     certStore = certStoreFactory.Create<RIBCertStore>();
@@ -42,6 +46,7 @@ ApplicationContainer RIB::Install(Ptr<Node> node)
     linkManager->SetContext((void *)this);
     adStore->SetContext((void *)this);
     certStore->SetContext((void *)this);
+    pathComputer->SetContext((void *)this);
     
     ApplicationContainer apps;
     apps.Add(adStore);

--- a/ribadstore.cc
+++ b/ribadstore.cc
@@ -376,6 +376,24 @@ namespace ns3
                     if (!trust_curr_AS&&is_origin_AS_for_curr_ad) {
                         NS_LOG_INFO("I am origin AS, trust relationship does not exist, thus dropping this advertisement from the DC server advertiser.....");
                     }
+                    
+                    // save the received trust and distrust relations in local ribcertstore cache
+                    if (!is_origin_AS_for_curr_ad) {
+                        // * if not empty trust relation, add to cache
+                        if ( !(advertised_entry->trust_cert.issuer.size() == 0
+                            && advertised_entry->trust_cert.entity.size() == 0
+                            && advertised_entry->trust_cert.r_transitivity == 0) ) {
+                                std::pair<std::string, int> __val = std::make_pair(advertised_entry->trust_cert.entity, advertised_entry->trust_cert.r_transitivity);
+                                rib->trustRelations->insert(std::make_pair(advertised_entry->trust_cert.issuer, __val));
+                        }
+
+                        if (advertised_entry->distrust_certs.size() != 0) {
+                            for (auto& item : advertised_entry->distrust_certs) {
+                                rib->distrustRelations->insert(std::make_pair(item.issuer, item.entity));
+                            }
+                        }
+                    }
+
                     if ((trust_curr_AS&&is_origin_AS_for_curr_ad) || !is_origin_AS_for_curr_ad) {
                         for (auto& [AS_num, addr] : rib->peers) {
                             //   cases not to forward:

--- a/ribadstore.cc
+++ b/ribadstore.cc
@@ -350,10 +350,19 @@ namespace ns3
                             // check if "entity" is the data capsule name
                             if (Ipv4Address((it->second.first).c_str()) == advertised_entry->origin_server) {
                                 trust_curr_AS = true;
-                                advertised_entry->cert_info.issuer = it->first;
-                                advertised_entry->cert_info.entity = it->second.first;
-                                advertised_entry->cert_info.r_transitivity = it->second.second;
-                                advertised_entry->cert_info.type = "trust";
+                                // * Attach trust from DC owner to current name to the advertisement
+                                advertised_entry->trust_cert.issuer = it->first;
+                                advertised_entry->trust_cert.entity = it->second.first;
+                                advertised_entry->trust_cert.r_transitivity = it->second.second;
+                                advertised_entry->trust_cert.type = "trust";
+                                // * Attach distrust relations of the DC owner
+                                auto& distrust_relation_map = rib->certStore->distrustRelations;
+                                auto [range_start, range_stop] = distrust_relation_map.equal_range("fogrobotics:" + advertised_entry->dc_name);
+                                for (auto it = range_start; it != range_stop; ++it) {
+                                    advertised_entry->distrust_certs.push_back(
+                                        NameDBEntry::DistrustCert {"distrust", it->second, it->first}
+                                    );
+                                }
                                 serialized = advertised_entry->ToAdvertisementStr();
                                 break;
                             }

--- a/ribcertstore.cc
+++ b/ribcertstore.cc
@@ -1,0 +1,237 @@
+#include "main.h"
+
+namespace ns3
+{
+
+    NS_LOG_COMPONENT_DEFINE("RIBCertStore");
+
+    NS_OBJECT_ENSURE_REGISTERED(RIBCertStore);
+
+    TypeId
+    RIBCertStore::GetTypeId()
+    {
+        // void *x;
+        static TypeId tid =
+            TypeId("ns3::RIBCertStore")
+                .SetParent<Application>()
+                .SetGroupName("Applications")
+                .AddConstructor<RIBCertStore>()
+                .AddAttribute("Port",
+                            "Port on which we listen for incoming packets.",
+                            UintegerValue(RIBCERTSTORE_PORT),
+                            MakeUintegerAccessor(&RIBCertStore::m_port),
+                            MakeUintegerChecker<uint16_t>())
+                .AddAttribute("PacketWindowSize",
+                            "The size of the window used to compute the packet loss. This value "
+                            "should be a multiple of 8.",
+                            UintegerValue(32),
+                            MakeUintegerAccessor(&RIBCertStore::GetPacketWindowSize,
+                                                &RIBCertStore::SetPacketWindowSize),
+                            MakeUintegerChecker<uint16_t>(8, 256))
+                .AddTraceSource("Rx",
+                                "A packet has been received",
+                                MakeTraceSourceAccessor(&RIBCertStore::m_rxTrace),
+                                "ns3::Packet::TracedCallback")
+                .AddTraceSource("RxWithAddresses",
+                                "A packet has been received",
+                                MakeTraceSourceAccessor(&RIBCertStore::m_rxTraceWithAddresses),
+                                "ns3::Packet::TwoAddressTracedCallback");
+        return tid;
+    }
+
+    RIBCertStore::RIBCertStore()
+        : m_lossCounter(0)
+    {
+        NS_LOG_FUNCTION(this);
+        m_received = 0;
+        // parent_ctx = ctx;
+    }
+
+    void RIBCertStore::SetContext(void *ctx)
+    {
+        parent_ctx = ctx;
+    }
+
+    RIBCertStore::~RIBCertStore()
+    {
+        NS_LOG_FUNCTION(this);
+    }
+
+    uint16_t
+    RIBCertStore::GetPacketWindowSize() const
+    {
+        NS_LOG_FUNCTION(this);
+        return m_lossCounter.GetBitMapSize();
+    }
+
+    void
+    RIBCertStore::SetPacketWindowSize(uint16_t size)
+    {
+        NS_LOG_FUNCTION(this << size);
+        m_lossCounter.SetBitMapSize(size);
+    }
+
+    uint32_t
+    RIBCertStore::GetLost() const
+    {
+        NS_LOG_FUNCTION(this);
+        return m_lossCounter.GetLost();
+    }
+
+    uint64_t
+    RIBCertStore::GetReceived() const
+    {
+        NS_LOG_FUNCTION(this);
+        return m_received;
+    }
+
+    void
+    RIBCertStore::DoDispose()
+    {
+        NS_LOG_FUNCTION(this);
+        Application::DoDispose();
+    }
+
+    void
+    RIBCertStore::StartApplication()
+    {
+        NS_LOG_FUNCTION(this);
+        NS_LOG_INFO("RIBCertStore started");
+
+        if (!m_socket)
+        {
+            TypeId tid = TypeId::LookupByName("ns3::UdpSocketFactory");
+            m_socket = Socket::CreateSocket(GetNode(), tid);
+            InetSocketAddress local = InetSocketAddress(Ipv4Address::GetAny(), m_port);
+            if (m_socket->Bind(local) == -1)
+            {
+                NS_FATAL_ERROR("Failed to bind socket");
+            }
+        }
+
+        m_socket->SetRecvCallback(MakeCallback(&RIBCertStore::HandleRead, this));
+
+        if (!m_socket6)
+        {
+            TypeId tid = TypeId::LookupByName("ns3::UdpSocketFactory");
+            m_socket6 = Socket::CreateSocket(GetNode(), tid);
+            Inet6SocketAddress local = Inet6SocketAddress(Ipv6Address::GetAny(), m_port);
+            if (m_socket6->Bind(local) == -1)
+            {
+                NS_FATAL_ERROR("Failed to bind socket");
+            }
+        }
+
+        m_socket6->SetRecvCallback(MakeCallback(&RIBCertStore::HandleRead, this));
+
+    }
+
+    void
+    RIBCertStore::StopApplication()
+    {
+        NS_LOG_FUNCTION(this);
+
+        if (m_socket)
+        {
+            m_socket->SetRecvCallback(MakeNullCallback<void, Ptr<Socket>>());
+        }
+    }
+
+    void
+    RIBCertStore::HandleRead(Ptr<Socket> socket)
+    {
+        NS_LOG_FUNCTION(this << socket);
+        Ptr<Packet> packet;
+        Address from;
+        Address localAddress;
+        while ((packet = socket->RecvFrom(from)))
+        {
+            socket->GetSockName(localAddress);
+            m_rxTrace(packet);
+            m_rxTraceWithAddresses(packet, from, localAddress);
+            if (packet->GetSize() > 0){
+                SeqTsHeader seqTs;
+                packet->RemoveHeader(seqTs);
+                uint32_t currentSequenceNumber = seqTs.GetSeq();
+                uint32_t receivedSize = packet->GetSize();
+
+                /* Packet contents:
+                 * {
+                 *       "issuer": "DCOwnerName:DCName | ClientName",
+                 *       "type": "trust | distrust",
+                 *       "entity": "entity to trust/distrust",
+                 *       "r_transitivity": value
+                 * } 
+                 */
+
+                std::stringstream ss;
+                packet->CopyData(&ss, packet->GetSize());
+                std::string data = ss.str();
+                Json::Reader jsonReader;
+                Json::Value jsonData;
+                if (!jsonReader.parse(data, jsonData)){
+                    NS_LOG_INFO("Malformed JSON");
+                    continue;
+                }
+
+                if (!(
+                    jsonData.isMember("issuer") &&
+                    jsonData.isMember("type") &&
+                    jsonData.isMember("entity")
+                )){
+                    NS_LOG_INFO("Malformed JSON");
+                    continue;
+                }
+
+                if (jsonData["type"].asString() == "trust"){
+                    if (!jsonData.isMember("r_transitivity")){
+                        jsonData["r_transitivity"] = INT_MAX;
+                    }
+                }
+                
+                NS_LOG_INFO("JSON Parsed Successfully");
+                if (jsonData["type"].asString() == "trust"){
+                    std::pair<std::string, int> __val = std::make_pair(jsonData["entity"].asString(), jsonData["r_transitivity"].asInt());
+                    trustRelations.insert(std::make_pair(
+                        jsonData["issuer"].asString(), __val));
+                }else if (jsonData["type"].asString() == "distrust"){
+                    distrustRelations.insert(std::make_pair(
+                        jsonData["issuer"].asString(), jsonData["entity"].asString()));
+                }
+
+                for (auto &x: trustRelations){
+                    NS_LOG_INFO("Trust Relation: " << x.first << " "
+                        << x.second.first << " " << x.second.second);
+                }
+
+                for (auto &x: distrustRelations){
+                    NS_LOG_INFO("Distrust Relation: " << x.first << " " << x.second);
+                }
+
+
+                if (InetSocketAddress::IsMatchingType(from))
+                {
+                    NS_LOG_INFO("TraceDelay: RX " << receivedSize << " bytes from "
+                                                << InetSocketAddress::ConvertFrom(from).GetIpv4()
+                                                << " Sequence Number: " << currentSequenceNumber
+                                                << " Uid: " << packet->GetUid() << " TXtime: "
+                                                << seqTs.GetTs() << " RXtime: " << Simulator::Now()
+                                                << " Delay: " << Simulator::Now() - seqTs.GetTs());
+                }
+                else if (Inet6SocketAddress::IsMatchingType(from))
+                {
+                    NS_LOG_INFO("TraceDelay: RX " << receivedSize << " bytes from "
+                                                << Inet6SocketAddress::ConvertFrom(from).GetIpv6()
+                                                << " Sequence Number: " << currentSequenceNumber
+                                                << " Uid: " << packet->GetUid() << " TXtime: "
+                                                << seqTs.GetTs() << " RXtime: " << Simulator::Now()
+                                                << " Delay: " << Simulator::Now() - seqTs.GetTs());
+                }
+
+                m_lossCounter.NotifyReceived(currentSequenceNumber);
+                m_received++;
+            }
+        }
+    }
+
+}

--- a/ribpathcomputer.cc
+++ b/ribpathcomputer.cc
@@ -1,0 +1,276 @@
+#include "main.h"
+
+namespace ns3
+{
+
+    NS_LOG_COMPONENT_DEFINE("RIBPathComputer");
+
+    NS_OBJECT_ENSURE_REGISTERED(RIBPathComputer);
+
+    TypeId
+    RIBPathComputer::GetTypeId()
+    {
+        static TypeId tid =
+            TypeId("ns3::RIBPathComputer")
+                .SetParent<Application>()
+                .SetGroupName("Applications")
+                .AddConstructor<RIBPathComputer>()
+                .AddAttribute("Port",
+                            "Port on which we listen for incoming packets.",
+                            UintegerValue(RIBLSM_PORT),
+                            MakeUintegerAccessor(&RIBPathComputer::m_port),
+                            MakeUintegerChecker<uint16_t>())
+                .AddAttribute("PacketWindowSize",
+                            "The size of the window used to compute the packet loss. This value "
+                            "should be a multiple of 8.",
+                            UintegerValue(32),
+                            MakeUintegerAccessor(&RIBPathComputer::GetPacketWindowSize,
+                                                &RIBPathComputer::SetPacketWindowSize),
+                            MakeUintegerChecker<uint16_t>(8, 256))
+                .AddTraceSource("Rx",
+                                "A packet has been received",
+                                MakeTraceSourceAccessor(&RIBPathComputer::m_rxTrace),
+                                "ns3::Packet::TracedCallback")
+                .AddTraceSource("RxWithAddresses",
+                                "A packet has been received",
+                                MakeTraceSourceAccessor(&RIBPathComputer::m_rxTraceWithAddresses),
+                                "ns3::Packet::TwoAddressTracedCallback");
+        return tid;
+    }
+
+    RIBPathComputer::RIBPathComputer()
+        : m_lossCounter(0)
+    {
+        NS_LOG_FUNCTION(this);
+        m_received = 0;
+        parent_ctx = NULL;
+        trust_graph.__node_cnt = 0;
+    }
+
+    RIBPathComputer::~RIBPathComputer()
+    {
+        NS_LOG_FUNCTION(this);
+    }
+
+    uint16_t
+    RIBPathComputer::GetPacketWindowSize() const
+    {
+        NS_LOG_FUNCTION(this);
+        return m_lossCounter.GetBitMapSize();
+    }
+
+    void
+    RIBPathComputer::SetPacketWindowSize(uint16_t size)
+    {
+        NS_LOG_FUNCTION(this << size);
+        m_lossCounter.SetBitMapSize(size);
+    }
+
+    uint32_t
+    RIBPathComputer::GetLost() const
+    {
+        NS_LOG_FUNCTION(this);
+        return m_lossCounter.GetLost();
+    }
+
+    uint64_t
+    RIBPathComputer::GetReceived() const
+    {
+        NS_LOG_FUNCTION(this);
+        return m_received;
+    }
+
+    void
+    RIBPathComputer::DoDispose()
+    {
+        NS_LOG_FUNCTION(this);
+        Application::DoDispose();
+    }
+
+    void
+    RIBPathComputer::StartApplication()
+    {
+        NS_LOG_FUNCTION(this);
+
+        if (!m_socket)
+        {
+            TypeId tid = TypeId::LookupByName("ns3::UdpSocketFactory");
+            m_socket = Socket::CreateSocket(GetNode(), tid);
+            InetSocketAddress local = InetSocketAddress(Ipv4Address::GetAny(), m_port);
+            if (m_socket->Bind(local) == -1)
+            {
+                NS_FATAL_ERROR("Failed to bind socket");
+            }
+        }
+
+        m_socket->SetRecvCallback(MakeCallback(&RIBPathComputer::HandleRead, this));
+
+        if (!m_socket6)
+        {
+            TypeId tid = TypeId::LookupByName("ns3::UdpSocketFactory");
+            m_socket6 = Socket::CreateSocket(GetNode(), tid);
+            Inet6SocketAddress local = Inet6SocketAddress(Ipv6Address::GetAny(), m_port);
+            if (m_socket6->Bind(local) == -1)
+            {
+                NS_FATAL_ERROR("Failed to bind socket");
+            }
+        }
+
+        m_socket6->SetRecvCallback(MakeCallback(&RIBPathComputer::HandleRead, this));
+
+        Simulator::Schedule(Seconds(0.5), &RIBPathComputer::ComputeGraph, this);
+    }
+
+    void
+    RIBPathComputer::StopApplication()
+    {
+        NS_LOG_FUNCTION(this);
+
+        if (m_socket)
+        {
+            m_socket->SetRecvCallback(MakeNullCallback<void, Ptr<Socket>>());
+        }
+    }
+
+    void
+    RIBPathComputer::HandleRead(Ptr<Socket> socket)
+    {
+        // NS_LOG_FUNCTION(this << socket);
+        Ptr<Packet> packet;
+        Address from;
+        Address localAddress;
+        while ((packet = socket->RecvFrom(from)))
+        {
+            socket->GetSockName(localAddress);
+            m_rxTrace(packet);
+            m_rxTraceWithAddresses(packet, from, localAddress);
+            if (packet->GetSize() > 0)
+            {
+                continue;
+                SeqTsHeader seqTs;
+                packet->RemoveHeader(seqTs);
+                
+                NS_LOG_INFO("Received link state packet: " << seqTs.GetSeq() << " " << seqTs.GetTs());
+                
+
+                uint32_t currentSequenceNumber = seqTs.GetSeq();
+                if (InetSocketAddress::IsMatchingType(from))
+                {
+                    // NS_LOG_INFO("TraceDelay: RX " << receivedSize << " bytes from "
+                                                // << InetSocketAddress::ConvertFrom(from).GetIpv4()
+                                                // << " Sequence Number: " << currentSequenceNumber
+                                                // << " Uid: " << packet->GetUid() << " TXtime: "
+                                                // << seqTs.GetTs() << " RXtime: " << Simulator::Now()
+                                                // << " Delay: " << Simulator::Now() - seqTs.GetTs());
+                }
+                else if (Inet6SocketAddress::IsMatchingType(from))
+                {
+                    // NS_LOG_INFO("TraceDelay: RX " << receivedSize << " bytes from "
+                                                // << Inet6SocketAddress::ConvertFrom(from).GetIpv6()
+                                                // << " Sequence Number: " << currentSequenceNumber
+                                                // << " Uid: " << packet->GetUid() << " TXtime: "
+                                                // << seqTs.GetTs() << " RXtime: " << Simulator::Now()
+                                                // << " Delay: " << Simulator::Now() - seqTs.GetTs());
+                }
+
+                m_lossCounter.NotifyReceived(currentSequenceNumber);
+                m_received++;
+            }
+        }
+    }
+
+    void
+    RIBPathComputer::SetContext(void *ctx)
+    {
+        parent_ctx = ctx;
+    }
+
+    void
+    RIBPathComputer::ComputeGraph()
+    {
+        Simulator::Schedule(Seconds(1.0), &RIBPathComputer::ComputeGraph, this);
+
+        if (!parent_ctx){
+            NS_LOG_INFO("No RIB");
+            return;
+        }
+
+        RIB *rib = (RIB *)parent_ctx;
+        if (!(rib->trustRelations && rib->distrustRelations)){
+            NS_LOG_INFO("No Trust/Distrust Relations");
+            return;
+        }
+
+        NS_LOG_INFO("Recalculating Trust Relation Graph...");
+
+        for (auto &x: *(rib->trustRelations)){
+            if (trust_graph.nodes_to_id.find(x.first) == trust_graph.nodes_to_id.end()){
+                trust_graph.nodes_to_id[x.first] = trust_graph.__node_cnt++;
+            }
+
+            if (trust_graph.nodes_to_id.find(x.second.first) == trust_graph.nodes_to_id.end()){
+                trust_graph.nodes_to_id[x.second.first] = trust_graph.__node_cnt++;
+            }
+
+            int id1 = trust_graph.nodes_to_id[x.first];
+            int id2 = trust_graph.nodes_to_id[x.second.first];
+            auto it2 = trust_graph.trust_edges.equal_range(id1);
+            bool found = false;
+            for (auto __it = it2.first; __it != it2.second; __it++){
+                if (__it->second == id2){
+                    found = true;
+                    break;
+                }
+            }
+            if (!found){
+                trust_graph.trust_edges.insert({id1, id2});
+            }
+
+            if (x.second.second != INT_MAX){
+                // Only add an entry if the r_transitivity is not infinite.
+                // Typically only DCOwners and Users can specify r_transitivity
+                trust_graph.transitivity[{id1, id2}] = x.second.second;
+            }
+        }
+
+        for (auto &x: *(rib->distrustRelations)){
+            if (trust_graph.nodes_to_id.find(x.first) == trust_graph.nodes_to_id.end()){
+                trust_graph.nodes_to_id[x.first] = trust_graph.__node_cnt++;
+            }
+
+            if (trust_graph.nodes_to_id.find(x.second) == trust_graph.nodes_to_id.end()){
+                trust_graph.nodes_to_id[x.second] = trust_graph.__node_cnt++;
+            }
+
+            int id1 = trust_graph.nodes_to_id[x.first];
+            int id2 = trust_graph.nodes_to_id[x.second];
+
+            auto it2 = trust_graph.distrust_edges.equal_range(id1);
+            bool found = false;
+            for (auto __it = it2.first; __it != it2.second; __it++){
+                if (__it->second == id2){
+                    found = true;
+                    break;
+                }
+            }
+            if (!found){
+                trust_graph.distrust_edges.insert({id1, id2});
+            }
+        }
+
+        for (auto &x: trust_graph.nodes_to_id){
+            NS_LOG_INFO("Node Entry: " << x.first << "\t" << x.second);
+        }
+        for (auto &x: trust_graph.trust_edges){
+            auto it = trust_graph.transitivity.find({x.first, x.second});
+            if (it != trust_graph.transitivity.end()){
+                NS_LOG_INFO("Trust Edge: " << x.first << " -> " << x.second << " (" << it->second << ")");
+            }else{
+                NS_LOG_INFO("Trust Edge: " << x.first << " -> " << x.second);
+            }
+        }
+        for (auto &x: trust_graph.distrust_edges){
+            NS_LOG_INFO("Distrust Edge: " << x.first << " -> " << x.second);
+        }
+    }
+}

--- a/ribtraceroute.cc
+++ b/ribtraceroute.cc
@@ -189,6 +189,9 @@ RIBTraceRoute::StopApplication()
                 if (as != parent_ctx->td_num){
                     parent_ctx->peers[as] = m_remote;
 
+
+
+
                     std::stringstream asstr;
                     asstr << "AS" << as;
                     parent_ctx->trustRelations->insert(std::make_pair(std::string("me"),

--- a/ribtraceroute.cc
+++ b/ribtraceroute.cc
@@ -188,6 +188,11 @@ RIBTraceRoute::StopApplication()
             for (auto &as: all_as){
                 if (as != parent_ctx->td_num){
                     parent_ctx->peers[as] = m_remote;
+
+                    std::stringstream asstr;
+                    asstr << "AS" << as;
+                    parent_ctx->trustRelations->insert(std::make_pair(std::string("me"),
+                        std::make_pair(asstr.str(), INT_MAX)));
                     // setup global mapping between ASes and their addresses
                     global_addr_to_AS[m_remote] = as;
                     global_AS_to_addr[as] = m_remote;


### PR DESCRIPTION
This is still in progress!!!

**Goal:** 
Origin ASes should tell peers the trust/distrust relations of the DC that is hosted by a DC server in them. Say there is a DC called "fogrobotics", an AS called "A", and a server called "S". When A receives an advertisement from S claiming to host fogrobotics, the AS should first check if the server is allowed to host the name by checking the trust relations (whether or not the DC owner give explicit trust to the server ip).
 
If the answer is yes, then the trust relation between the DC owner and the AS and all the distrust relations by the DC owner should together be flooded to peers along with the actual name advertisement.

- [x] send trust relation between DC owner and server along with name advertisement
- [x] all distrusted entities with name advertisement
- [x] from a peer's perspective, insert and manage the received trust/distrust relations
...